### PR TITLE
Change style of initializer to 'Apple's typical init'

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,19 +171,18 @@ computations.
 
 Initializers
 ------------
-* Always do assignment of `self`, call `super` (or the designated initializer) and return early on failure.
+* Follow [Apple's typical init format](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/EncapsulatingData/EncapsulatingData.html#//apple_ref/doc/uid/TP40011210-CH5-SW11) to initialize objects.
 
 **Example:**
 
 ```objc
-- (instancetype)initWithName:(NSString *)name
-{
-    if (!(self = [super init])) {
-        return nil;
+- (id)init {
+    self = [super init];
+ 
+    if (self) {
+        // initialize instance variables here
     }
-
-    _name = name;
-
+ 
     return self;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ Initializers
 **Example:**
 
 ```objc
-- (id)init {
+- (id)init 
+{
     self = [super init];
  
     if (self) {

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Initializers
 **Example:**
 
 ```objc
-- (id)init 
+- (instancetype)init 
 {
     self = [super init];
  


### PR DESCRIPTION
Our previous initiailzer style prevented us from reaching 100% coverage on our unit tests and it would raise issues on static analysis due to nullability in Obj-C.
