### PR TITLE
Update documentation style recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,8 @@ stop(); // Hammer-time!
 ```
 
 * Document all methods and properties in the headers using Xcode’s documentation style. You can select a property
-or method and use `Cmd`-`/` to see this in action. Make sure to use the available markup tags like `@param`,
-`@return`, etc. (these will be auto-generated for you by Xcode). The `///` form is preferred for single line
-comments, and `/** */` for multi-line comments. Use the same formatting as in the example block above.
+or method and use `Option`+`Cmd`+`/` to see this in action. Make sure to use the available markup tags like `@param`,
+`@return`, etc. (these will be auto-generated for you by Xcode).
 
 Pragma Marks
 ------------

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ stop(); // Hammer-time!
 // this is a very brief comment.
 ```
 
-* Document all methods and properties in the headers using Xcode’s documentation style. You can select a property
-or method and use `Option`+`Cmd`+`/` to see this in action. Make sure to use the available markup tags like `@param`,
-`@return`, etc. (these will be auto-generated for you by Xcode).
+* Document all methods and properties in the headers using Xcode’s documentation style (which is `///` at the time of writing). 
+You can select a property or method and use `Option`+`Cmd`+`/` to generate the documentation template for it. Make sure to use the available 
+markup tags like `@param`, `@return`, etc. (these will be auto-generated for you by Xcode).
 
 Pragma Marks
 ------------


### PR DESCRIPTION
The new auto-generated Xcode docs use `///` for both single- and multi-line comments, so our recommendations are a little outdated.